### PR TITLE
Recursively find complete window tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.11)
+project(ueberzug LANGUAGES C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(Python_FIND_VIRTUALENV FIRST)
+find_package(PythonInterp 3.6 REQUIRED)
+
+exec_program(${PYTHON_EXECUTABLE}
+    ARGS "-c \"import sysconfig; print(sysconfig.get_paths()['include'])\""
+    OUTPUT_VARIABLE PYTHON_INCLUDE_DIRS
+    RETURN_VALUE PYTHON_INCLUDE_DIRS_NOT_FOUND
+    )
+if(PYTHON_INCLUDE_DIRS_NOT_FOUND)
+    message(FATAL_ERROR "Python headers not found")
+endif()
+
+find_package(X11 REQUIRED)
+pkg_check_modules(XEXT xext REQUIRED IMPORTED_TARGET)
+pkg_check_modules(XRES xres REQUIRED IMPORTED_TARGET)
+
+set(UEBERZUG_SOURCES
+    "ueberzug/X/X.c"
+    "ueberzug/X/Xshm.c"
+    "ueberzug/X/display.c"
+    "ueberzug/X/window.c"
+)
+
+add_library(ueberzug SHARED ${UEBERZUG_SOURCES})
+
+set_target_properties(
+    ueberzug
+    PROPERTIES
+        PREFIX ""
+        OUTPUT_NAME "X"
+        LINKER_LANGUAGE C
+)
+
+target_include_directories(ueberzug PUBLIC
+    ${PYTHON_INCLUDE_DIRS}
+    ${PROJECT_SOURCE_DIR}/ueberzug/X
+)
+
+target_link_libraries(ueberzug X11::X11 PkgConfig::XEXT PkgConfig::XRES)

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,78 @@
 #!/usr/bin/env python3
 import distutils.core
-import setuptools
+import sys
+import os
+import subprocess
+import pprint
 import glob
 
 import ueberzug
+
+from setuptools import setup, Extension, find_packages
+from setuptools.command.build_ext import build_ext
 # To use a consistent encoding
 
 # Arguments marked as "Required" below must be included for upload to PyPI.
 # Fields marked as "Optional" may be commented out.
 
-setuptools.setup(
+# Filename for the C extension module library
+c_module_name = 'ueberzug.X'
+
+# Command line flags forwarded to CMake (for debug purpose)
+cmake_cmd_args = []
+for f in sys.argv:
+    if f.startswith('-D'):
+        cmake_cmd_args.append(f)
+
+for f in cmake_cmd_args:
+    sys.argv.remove(f)
+
+
+def _get_env_variable(name, default='OFF'):
+    if name not in os.environ.keys():
+        return default
+    return os.environ[name]
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, cmake_lists_dir='.', sources=[], **kwa):
+        Extension.__init__(self, name, sources=sources, **kwa)
+        self.cmake_lists_dir = os.path.abspath(cmake_lists_dir)
+
+class CMakeBuild(build_ext):
+    def build_extensions(self):
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError('Cannot find CMake executable')
+
+        for ext in self.extensions:
+
+            extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+            cfg = 'Debug' if _get_env_variable('UEBERZUG_DEBUG') == 'ON' else 'Release'
+
+            cmake_args = [
+                '-DUEBERZUG_PYTHON_C_MODULE_NAME=%s' % c_module_name,
+                '-DCMAKE_BUILD_TYPE=%s' % cfg,
+                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir),
+                '-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), self.build_temp),
+                '-DPYTHON_EXECUTABLE={}'.format(sys.executable),
+            ]
+
+            cmake_args += cmake_cmd_args
+
+            pprint.pprint(cmake_args)
+
+            if not os.path.exists(self.build_temp):
+                os.makedirs(self.build_temp)
+
+            # Config and build the extension
+            subprocess.check_call(['cmake', ext.cmake_lists_dir] + cmake_args,
+                                  cwd=self.build_temp)
+            subprocess.check_call(['cmake', '--build', '.', '--config', cfg],
+                                  cwd=self.build_temp)
+
+setup(
     # This is the name of your project. The first time you publish this
     # package, this name will be registered for you. It will determine how
     # users can install this project, e.g.:
@@ -24,7 +87,7 @@ setuptools.setup(
     name='ueberzug',  # Required
     license=ueberzug.__license__,
 
-    include_package_data=True,
+    #include_package_data=True,
     package_data={
         '': ['*.sh'],
     },
@@ -33,13 +96,8 @@ setuptools.setup(
             'ueberzug=ueberzug.__main__:main'
         ]
     },
-    ext_modules=[
-        distutils.core.Extension(
-            "ueberzug.X",
-            glob.glob("ueberzug/X/*.c"),
-            libraries=["X11", "Xext", "XRes"],
-            include_dirs=["ueberzug/X"]),
-    ],
+    ext_modules=[CMakeExtension(c_module_name)],
+    cmdclass={'build_ext': CMakeBuild},
 
     # Versions should comply with PEP 440:
     # https://www.python.org/dev/peps/pep-0440/
@@ -92,7 +150,7 @@ setuptools.setup(
     #
     #   py_modules=["my_module"],
     #
-    packages=setuptools.find_packages(),  # Required
+    packages=find_packages(),  # Required
 
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is

--- a/ueberzug/X/display.c
+++ b/ueberzug/X/display.c
@@ -154,8 +154,6 @@ Display_get_child_window_ids(DisplayObject *self, PyObject *args, PyObject *kwds
             PyList_Append(child_ids, py_window_id);
             Py_XDECREF(py_window_id);
         }
-
-        fprintf(stderr, "\n");
         XFree(children);
     }
 

--- a/ueberzug/X/display.c
+++ b/ueberzug/X/display.c
@@ -3,6 +3,8 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/XRes.h>
 #include <X11/extensions/XShm.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "util.h"
 #include "display.h"
@@ -92,13 +94,40 @@ has_property(DisplayObject *self, Window window, Atom property) {
     return status == Success && !(actual_type_return == None && actual_format_return == 0);
 }
 
+static void
+get_child_window_ids_helper(Display *display, Window window,
+        Window **total_children, unsigned int *total_num_children) {
+    Window _, *children;
+    unsigned int num_children;
+
+    XQueryTree(display, window, &_, &_, &children, &num_children);
+    if (!children) return;
+
+    if (!*total_children) {
+        *total_children = calloc(num_children, sizeof(Window));
+    } else {
+        Window *tmp = reallocarray(*total_children, num_children + *total_num_children, sizeof(Window));
+        if (tmp) {
+            *total_children = tmp;
+        }
+    }
+
+    for (int i = 0; i < num_children; ++i) {
+        (*total_children)[i + *total_num_children] = children[i];
+    }
+    *total_num_children += num_children;
+
+    for (int i = 0; i < num_children; ++i) {
+        get_child_window_ids_helper(display, children[i], total_children, total_num_children);
+    }
+}
 
 static PyObject *
 Display_get_child_window_ids(DisplayObject *self, PyObject *args, PyObject *kwds) {
     static char *kwlist[] = {"parent_id", NULL};
     Window parent = XDefaultRootWindow(self->info_display);
-    Window _, *children;
-    unsigned int children_count;
+    Window *children = NULL;
+    unsigned int children_count = 0;
 
     if (!PyArg_ParseTupleAndKeywords(
             args, kwds, "|k", kwlist,
@@ -106,11 +135,7 @@ Display_get_child_window_ids(DisplayObject *self, PyObject *args, PyObject *kwds
         Py_RETURN_ERROR;
     }
 
-    if (!XQueryTree(
-            self->info_display, parent,
-            &_, &_, &children, &children_count)) {
-        raise(OSError, "failed to query child windows of %lu", parent);
-    }
+    get_child_window_ids_helper(self->info_display, parent, &children, &children_count);
 
     PyObject *child_ids = PyList_New(0);
     if (children) {
@@ -129,6 +154,8 @@ Display_get_child_window_ids(DisplayObject *self, PyObject *args, PyObject *kwds
             PyList_Append(child_ids, py_window_id);
             Py_XDECREF(py_window_id);
         }
+
+        fprintf(stderr, "\n");
         XFree(children);
     }
 
@@ -169,7 +196,7 @@ Display_get_window_pid(DisplayObject *self, PyObject *args, PyObject *kwds) {
     }
 
     XFree(client_ids);
-
+    
     if (window_creator_pid != INVALID_PID) {
         return Py_BuildValue("i", window_creator_pid);
     }

--- a/ueberzug/X/display.c
+++ b/ueberzug/X/display.c
@@ -194,7 +194,7 @@ Display_get_window_pid(DisplayObject *self, PyObject *args, PyObject *kwds) {
     }
 
     XFree(client_ids);
-    
+
     if (window_creator_pid != INVALID_PID) {
         return Py_BuildValue("i", window_creator_pid);
     }


### PR DESCRIPTION
Previosly, the C extension only used an incomplete window tree (single XQueryTree call), it should now obtain a complete window tree. This has fixed a tmux issue (images not showing up), it should theoretically also add better (? tabbed support.

I added CMake for the creation of a compile_commands.json file to aid in the c extension development.